### PR TITLE
Ignore vulnerability support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,20 @@ build:
         	shrinkwrap-path: src/npm-shrinkwrap.json
 ```
 
+It is also possible to ignore advisories for modules:
+
+```
+build:
+    steps:
+        - shrinkwrap-security-audit:
+            ignore: >
+                qs=https://nodesecurity.io/advisories/28,
+                qs=https://nodesecurity.io/advisories/29
+```
+
 # What's new
 
-Switched api call to api.nodesecurity.io. Output has also been improved showing the path of the module
-that has the vulnerability. Example output:
+Switched api call to api.nodesecurity.io. Output has also been improved showing the path of the module  that has the vulnerability. Example output:
 
 ``` text
 2 vulnerabilities/issues detected:
@@ -51,6 +61,7 @@ Advisory: https://nodesecurity.io/advisories/29
 # Options
 
 - `shrinkwrap-path` (optional) The path to the shrinkwrap file. Defaults to `./npm-shrinkwrap.json`.
+- `ignore` (optional) Comma separated list of advisories to ignore. The list is formatted as: moduleA=advisoryURL, moduleB=advisoryURL
 
 # TODO
 
@@ -61,6 +72,9 @@ TODO
 The MIT License (MIT)
 
 # Changelog
+
+## 2.1.0
+- add `ignore` support
 
 ## 2.0.0
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 # Check if command exists exists in the current path
 # $1: Name of the command to check
@@ -23,22 +24,22 @@ is_file() {
 security_audit() {
     local step_path=$1
     local shrinkwrap_path=$2
-    
+
     node "$step_path/bin/security_audit.js" "$shrinkwrap_path"
 }
 
-# Get the path to the shrinkwrap file. First checks the wercker parameter, 
+# Get the path to the shrinkwrap file. First checks the wercker parameter,
 # otherwise uses the default "./npm-shrinkwrap.json"
 # returns the path by echo
 get_shrinkwrap_path() {
     if [ -n "$WERCKER_SHRINKWRAP_SECURITY_AUDIT_SHRINKWRAP_PATH" ]; then
         echo "$WERCKER_SHRINKWRAP_SECURITY_AUDIT_SHRINKWRAP_PATH"
-    else 
+    else
         echo "./npm-shrinkwrap.json"
     fi
 }
 
-# Get the path to the wercker step root. First checks if running in a wercker environment, 
+# Get the path to the wercker step root. First checks if running in a wercker environment,
 # otherwise uses the $PWD
 # returns the path by echo
 get_step_path() {
@@ -49,18 +50,31 @@ get_step_path() {
     fi
 }
 
+get_ignores() {
+    if [ -n "$WERCKER_SHRINKWRAP_SECURITY_AUDIT_SHRINKWRAP_IGNORE" ]; then
+        echo "$WERCKER_SHRINKWRAP_SECURITY_AUDIT_SHRINKWRAP_IGNORE";
+    else
+        echo ""
+    fi
+}
+
 main() {
     set -e
     if ! command_exists "node"; then
         fail "node not found, make sure it exists in the \$PATH"
     fi
-    
-    local step_path=$(get_step_path)
-    local shrinkwrap_path=$(get_shrinkwrap_path)
 
-    if is_file "$shrinkwrap_path"; then 
-        security_audit "$step_path" "$shrinkwrap_path"
-    else 
+    local step_path
+    local shrinkwrap_path
+    local ignores
+
+    step_path=$(get_step_path)
+    shrinkwrap_path=$(get_shrinkwrap_path)
+    ignores=$(get_ignores)
+
+    if is_file "$shrinkwrap_path"; then
+        security_audit "$step_path" "$shrinkwrap_path" "$ignores"
+    else
         fail "Shrinkwrap file was not found"
     fi
 }

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: shrinkwrap-security-audit
-version: 2.0.0
+version: 1.0.0
 description: A step to check the npm-shrinkwrap.json file for vulnerable modules using nodesecurity.io
 keywords:
   - security
@@ -7,3 +7,7 @@ keywords:
   - shrinkwrap
   - npm
   - nodesecurity.io
+properties:
+  ignore:
+    type: string
+    required: false

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,6 @@
 box: wercker/ubuntu12.04-nodejs0.10
-build: 
+build:
     steps:
         - validate-wercker-step
+        - shellcheck
         - npm-install


### PR DESCRIPTION
You can now specify which vulnerabilities should be ignored. 
Running the following wercker.yml:
```
build:
    steps:
        - shrinkwrap-security-audit:
            ignore: >
                qs=https://nodesecurity.io/advisories/28,
                qs=https://nodesecurity.io/advisories/29
```

Can now result in the following output:

```
Ingoring:
 - module: qs
   - https://nodesecurity.io/advisories/28
   - https://nodesecurity.io/advisories/29

2 vulnerabilities/issues detected:

Title:    Denial-of-Service Extended Event Loop Blocking (ingored)
Module:   qs
version:  0.6.6
Patched:  >= 1.x
Path:     request > qs
Advisory: https://nodesecurity.io/advisories/28

Title:    Denial-of-Service Memory Exhaustion (ingored)
Module:   qs
version:  0.6.6
Patched:  >= 1.x
Path:     request > qs
Advisory: https://nodesecurity.io/advisories/29

Ignored all found vulnerabilities
```